### PR TITLE
商品詳細表示機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,3 +67,5 @@ gem 'gimei'
 gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 gem 'active_hash'
+
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.0.3.5)
       actionpack (= 6.0.3.5)
       activesupport (= 6.0.3.5)
@@ -293,6 +296,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails (~> 4.0.0)
   rubocop
   sass-rails (~> 5)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,10 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-
   private
-  def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birthday])
-  end
 
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up,
+                                      keys: [:nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birthday])
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new]
+  before_action :authenticate_user!, only: [:new, :create]
 
   def index
     @items = Item.all.order('created_at DESC')

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,6 +19,10 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.find(params[:id])
+  end
+
+  def edit
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new
@@ -18,10 +18,13 @@ class ItemsController < ApplicationController
     end
   end
 
-  private
-  def item_params
-    params.require(:item).permit(:product, :description, :category_id, :condition_id,
-      :charge_id, :shipment_id, :day_id, :price, :user, :image).merge(user_id: current_user.id)
+  def show
   end
 
+  private
+
+  def item_params
+    params.require(:item).permit(:product, :description, :category_id, :condition_id,
+                                 :charge_id, :shipment_id, :day_id, :price, :user, :image).merge(user_id: current_user.id)
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,4 @@
 class UsersController < ApplicationController
-  
   def show
     @user = User.find(params[:id])
   end
@@ -7,6 +6,4 @@ class UsersController < ApplicationController
   def create
     @user = User.new
   end
-
-
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -15,5 +15,4 @@ class Category < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -2,10 +2,9 @@ class Charge < ActiveHash::Base
   self.data = [
     { id: 1, name: '---' },
     { id: 2, name: '着払い(購入者負担)' },
-    { id: 3, name: '送料込み(出品者負担)' },
+    { id: 3, name: '送料込み(出品者負担)' }
   ]
 
   include ActiveHash::Associations
   has_many :items
-
-  end
+end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -6,10 +6,9 @@ class Condition < ActiveHash::Base
     { id: 4, name: '目立った傷や汚れなし' },
     { id: 5, name: 'やや傷や汚れあり' },
     { id: 6, name: '傷や汚れあり' },
-    { id: 7, name: '全体的に状態が悪い' },
+    { id: 7, name: '全体的に状態が悪い' }
   ]
 
   include ActiveHash::Associations
   has_many :items
-
-  end
+end

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -3,10 +3,9 @@ class Day < ActiveHash::Base
     { id: 1, name: '---' },
     { id: 2, name: '1~2日で発送' },
     { id: 3, name: '2~3日で発送' },
-    { id: 4, name: '4~7日で発送' },
+    { id: 4, name: '4~7日で発送' }
   ]
 
   include ActiveHash::Associations
   has_many :items
-
-  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,11 +1,12 @@
 class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
-  
 
   with_options presence: true do
     validates :product, :description, :image
-    validates :price, numericality: {only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999, message: 'Out of setting range'}
-    with_options numericality: { other_than: 1 ,message: "Select"}do
+    validates :price,
+              numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999,
+                              message: 'Out of setting range' }
+    with_options numericality: { other_than: 1, message: 'Select' } do
       validates :category_id, :condition_id, :charge_id, :shipment_id, :day_id
     end
   end
@@ -18,6 +19,6 @@ class Item < ApplicationRecord
 
   belongs_to :user
   has_many :comments
-  #has_one :buy
+  # has_one :buy
   has_one_attached :image
 end

--- a/app/models/shipment.rb
+++ b/app/models/shipment.rb
@@ -3,9 +3,9 @@ class Shipment < ActiveHash::Base
     { id: 1, name: '---' }, { id: 2, name: '北海道' }, { id: 3, name: '青森県' },
     { id: 4, name: '岩手県' },
     { id: 5, name: '宮城県' }, { id: 6, name: '秋田県' }, { id: 7, name: '山形県' },
-    { id: 8, name: '福島県' }, { id: 9, name: '茨城県'}, { id: 10, name: '栃木県' },
+    { id: 8, name: '福島県' }, { id: 9, name: '茨城県' }, { id: 10, name: '栃木県' },
     { id: 11, name: '群馬県' }, { id: 12, name: '埼玉県' }, { id: 13, name: '千葉県' },
-    { id: 14, name: '東京都' }, { id: 15, name: '神奈川県' }, {id: 16, name: '新潟県' },
+    { id: 14, name: '東京都' }, { id: 15, name: '神奈川県' }, { id: 16, name: '新潟県' },
     { id: 17, name: '富山県' }, { id: 18, name: '石川県' }, { id: 19, name: '福井県' },
     { id: 20, name: '山梨県' }, { id: 21, name: '長野県' }, { id: 22, name: '岐阜県' },
     { id: 23, name: '静岡県' }, { id: 24, name: '愛知県' }, { id: 25, name: '三重県' },
@@ -21,5 +21,4 @@ class Shipment < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :items
-
-  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,24 +4,24 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-        with_options presence: true do
-          validates :nickname
-          PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i.freeze
-          validates_format_of :password, with: PASSWORD_REGEX,message: 'Include both letters and numbers' 
-          with_options format: { with: /\A[ぁ-んァ-ン一-龥々]+\z/, message: "is invalid. Input full-width characters." } do
-            validates :first_name
-            validates :last_name
-          end
-          with_options format: { with: /\A[ァ-ヶー－]+\z/, message: "is invalid. Input full-width katakana characters." } do
-            validates :first_name_kana
-            validates :last_name_kana
-          end
-          with_options format: { with: /\A\d{4}-\d{2}-\d{2}\z/ } do
-            validates :birthday
-          end
-        end
+  with_options presence: true do
+    validates :nickname
+    PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
+    validates_format_of :password, with: PASSWORD_REGEX, message: 'Include both letters and numbers'
+    with_options format: { with: /\A[ぁ-んァ-ン一-龥々]+\z/, message: 'is invalid. Input full-width characters.' } do
+      validates :first_name
+      validates :last_name
+    end
+    with_options format: { with: /\A[ァ-ヶー－]+\z/, message: 'is invalid. Input full-width katakana characters.' } do
+      validates :first_name_kana
+      validates :last_name_kana
+    end
+    with_options format: { with: /\A\d{4}-\d{2}-\d{2}\z/ } do
+      validates :birthday
+    end
+  end
 
-        has_many :items
-        has_many :comments
-        #has_many :buys
+  has_many :items
+  has_many :comments
+  # has_many :buys
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
       <% if @items.present? %>
         <% @items.each do |item| %>
           <li class='list'>
-            <%= link_to "#" do %>
+            <%= link_to item_path(item.id) do %>
               <div class='item-img-content'>
                 <%= image_tag item.image, class: "item-img" if item.image.attached? %>
           

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,15 +26,16 @@
     </div>
 
 
-      <% if user_signed_in? && current_user.id == @item.user_id %>
-        <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
-        <p class="or-text">or</p>
-        <%= link_to "削除", item_path , method: :delete, class:"item-destroy" %>
-      <% else %>
-        <%# 商品が売れていない場合はこちらを表示しましょう %>
-        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-        <%# //商品が売れていない場合はこちらを表示しましょう %>
-
+      <% if user_signed_in? %>
+        <% if current_user.id == @item.user_id %>
+          <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
+          <p class="or-text">or</p>
+          <%= link_to "削除", item_path , method: :delete, class:"item-destroy" %>
+        <% else %>
+          <%# 商品が売れていない場合はこちらを表示しましょう %>
+          <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+          <%# //商品が売れていない場合はこちらを表示しましょう %>
+        <% end %>
       <% end %>
 
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,66 +4,66 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.product %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
+      <%#<div class="sold-out">
         <span>Sold Out!!</span>
       </div>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.charge.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+      <% if user_signed_in? && current_user.id == @item.user_id %>
+        <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", item_path , method: :delete, class:"item-destroy" %>
+      <% else %>
+        <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+        <%# //商品が売れていない場合はこちらを表示しましょう %>
 
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
+      <% end %>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.shipment.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.day.name %></td>
         </tr>
       </tbody>
     </table>
@@ -103,7 +103,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,13 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
+
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <%#<div class="sold-out">
         <span>Sold Out!!</span>
       </div>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
+
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -23,7 +25,7 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+
       <% if user_signed_in? && current_user.id == @item.user_id %>
         <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
@@ -34,7 +36,7 @@
         <%# //商品が売れていない場合はこちらを表示しましょう %>
 
       <% end %>
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+
 
     <div class="item-explain-box">
       <span><%= @item.description %></span>
@@ -102,9 +104,9 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+
   <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+
 </div>
 
 <%= render "shared/footer" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,8 +10,8 @@ module Furima32380
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
-    config.i18n.default_locale = :ja
-    config.time_zone = 'Tokyo'
+    #config.i18n.default_locale = :ja
+    #config.time_zone = 'Tokyo'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
   get 'items/index'
   root to: "items#index"
   resources :users, only: [:new, :create]
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
   get 'items/index'
   root to: "items#index"
   resources :users, only: [:new, :create]
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit, :destroy]
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
   get 'items/index'
   root to: "items#index"
   resources :users, only: [:new, :create]
-  resources :items, only: [:index, :new, :create, :show
+  resources :items, only: [:index, :new, :create, :show]
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
   get 'items/index'
   root to: "items#index"
   resources :users, only: [:new, :create]
-  resources :items, only: [:index, :new, :create, :show, :edit, :destroy]
+  resources :items, only: [:index, :new, :create, :show
 
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,14 +1,13 @@
 FactoryBot.define do
   factory :item do
-
-    product           {Faker::Lorem.sentence}
-    description       {Faker::Lorem.sentence}
-    category_id       {Faker::Number.between(from:2,to:11)}
-    condition_id      {Faker::Number.between(from:2,to:11)}
-    charge_id         {Faker::Number.between(from:2,to:11)}
-    shipment_id       {Faker::Number.between(from:2,to:11)}
-    day_id            {Faker::Number.between(from:2,to:11)}
-    price             {Faker::Number.between(from:300,to:9999999)}
+    product           { Faker::Lorem.sentence }
+    description       { Faker::Lorem.sentence }
+    category_id       { Faker::Number.between(from: 2, to: 11) }
+    condition_id      { Faker::Number.between(from: 2, to: 11) }
+    charge_id         { Faker::Number.between(from: 2, to: 11) }
+    shipment_id       { Faker::Number.between(from: 2, to: 11) }
+    day_id            { Faker::Number.between(from: 2, to: 11) }
+    price             { Faker::Number.between(from: 300, to: 9_999_999) }
     association :user
 
     after(:build) do |item|

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,14 +2,14 @@ FactoryBot.define do
   factory :user do
     gimei = Gimei.name
 
-    nickname              {Faker::Name.name}
-    email                 {Faker::Internet.free_email}
-    password              {Faker::Internet.password(min_length: 6, mix_case: true)}
-    password_confirmation {password}
-    last_name             {gimei.last.kanji}
-    first_name            {gimei.first.kanji}
-    last_name_kana        {gimei.last.katakana}
-    first_name_kana       {gimei.first.katakana}
-    birthday              {Faker::Date.birthday(min_age: 0, max_age: 100)}
+    nickname              { Faker::Name.name }
+    email                 { Faker::Internet.free_email }
+    password              { Faker::Internet.password(min_length: 6, mix_case: true) }
+    password_confirmation { password }
+    last_name             { gimei.last.kanji }
+    first_name            { gimei.first.kanji }
+    last_name_kana        { gimei.last.katakana }
+    first_name_kana       { gimei.first.katakana }
+    birthday              { Faker::Date.birthday(min_age: 0, max_age: 100) }
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -14,101 +14,100 @@ RSpec.describe Item, type: :model do
 
     context '商品出品がうまくいかないとき' do
       it '商品名が空では出品できない' do
-        @item.product = ""
+        @item.product = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include ("Product can't be blank")
+        expect(@item.errors.full_messages).to include("Product can't be blank")
       end
       it '商品説明が空では出品できない' do
-        @item.description = ""
+        @item.description = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include ("Description can't be blank")
+        expect(@item.errors.full_messages).to include("Description can't be blank")
       end
       it 'カテゴリーが空では出品できない' do
-        @item.category_id = ""
+        @item.category_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include ("Category can't be blank")
+        expect(@item.errors.full_messages).to include("Category can't be blank")
       end
       it 'カテゴリーのidが1以下では出品できない' do
-        @item.category_id = "1"
+        @item.category_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include ("Category Select")
+        expect(@item.errors.full_messages).to include('Category Select')
       end
       it '商品状態が空では出品できない' do
-        @item.condition_id = ""
+        @item.condition_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include ("Condition can't be blank")
+        expect(@item.errors.full_messages).to include("Condition can't be blank")
       end
       it '商品状態のidが1以下では出品できない' do
-        @item.condition_id = "1"
+        @item.condition_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include ("Condition Select")
+        expect(@item.errors.full_messages).to include('Condition Select')
       end
       it '配送料の負担が空では出品できない' do
-        @item.charge_id = ""
+        @item.charge_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include ("Charge can't be blank")
+        expect(@item.errors.full_messages).to include("Charge can't be blank")
       end
       it '配送料の負担のidが1以下では出品できない' do
-        @item.charge_id = "1"
+        @item.charge_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include ("Charge Select")
+        expect(@item.errors.full_messages).to include('Charge Select')
       end
       it '発送元の地域が空では出品できない' do
-        @item.shipment_id = ""
+        @item.shipment_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include ("Shipment can't be blank")
+        expect(@item.errors.full_messages).to include("Shipment can't be blank")
       end
       it '発送元の地域のidが1以下では出品できない' do
-        @item.shipment_id = "1"
+        @item.shipment_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include ("Shipment Select")
+        expect(@item.errors.full_messages).to include('Shipment Select')
       end
       it '発送までの日数が空では出品できない' do
-        @item.day_id = ""
+        @item.day_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include ("Day can't be blank")
+        expect(@item.errors.full_messages).to include("Day can't be blank")
       end
       it '発送までの日数のidが1以下では出品できない' do
-        @item.day_id = "1"
+        @item.day_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include ("Day Select")
+        expect(@item.errors.full_messages).to include('Day Select')
       end
       it '価格が空では出品できない' do
-        @item.price = ""
+        @item.price = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include ("Price can't be blank")
+        expect(@item.errors.full_messages).to include("Price can't be blank")
       end
       it '商品画像が空では出品できない' do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include ("Image can't be blank")
+        expect(@item.errors.full_messages).to include("Image can't be blank")
       end
       it '価格が9,999,999以上では出品できない' do
-        @item.price = "10000000"
+        @item.price = '10000000'
         @item.valid?
-        expect(@item.errors.full_messages).to include ("Price Out of setting range")
+        expect(@item.errors.full_messages).to include('Price Out of setting range')
       end
       it '価格が半角数字以外では出品できない' do
-        @item.price = "５０００"
+        @item.price = '５０００'
         @item.valid?
-        expect(@item.errors.full_messages).to include ("Price Out of setting range")
+        expect(@item.errors.full_messages).to include('Price Out of setting range')
       end
       it '価格が半角英数混合では登録できない' do
-        @item.price = "12ao"
+        @item.price = '12ao'
         @item.valid?
-        expect(@item.errors.full_messages).to include ("Price Out of setting range")
+        expect(@item.errors.full_messages).to include('Price Out of setting range')
       end
       it '価格が半角英語だけでは登録できない' do
-        @item.price = "lOOO"
+        @item.price = 'lOOO'
         @item.valid?
-        expect(@item.errors.full_messages).to include ("Price Out of setting range")
+        expect(@item.errors.full_messages).to include('Price Out of setting range')
       end
       it '価格が299円以下では登録できない' do
-      @item.price = "299"
+        @item.price = '299'
         @item.valid?
-        expect(@item.errors.full_messages).to include ("Price Out of setting range")
+        expect(@item.errors.full_messages).to include('Price Out of setting range')
       end
     end
   end
 end
-

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,129 +7,130 @@ RSpec.describe User, type: :model do
 
   describe 'ユーザー新規登録' do
     context '新規登録がうまくいくとき' do
-      it 'nickname、email、password,password_confirmation、last_name、first_name、last_name_kana、first_name_kana、birthdayが存在すれば登録できる' do
+      it 'nickname、email、password,password_confirmation、last_name、first_name、
+          last_name_kana、first_name_kana、birthdayが存在すれば登録できる' do
         expect(@user).to be_valid
       end
       it 'パスワードは6文字以上かつ英数字混合であれば登録できる' do
-        @user.password = "a00000"
-        @user.password_confirmation = "a00000"
+        @user.password = 'a00000'
+        @user.password_confirmation = 'a00000'
         expect(@user).to be_valid
       end
     end
 
     context '新規登録がうまくいかないとき' do
       it 'nicknameが空だと登録できない' do
-        @user.nickname = ""
+        @user.nickname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include ("Nickname can't be blank")
+        expect(@user.errors.full_messages).to include("Nickname can't be blank")
       end
       it 'emailが空では登録できない' do
         @user.email = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include ("Email can't be blank")
+        expect(@user.errors.full_messages).to include("Email can't be blank")
       end
       it 'emailが一意性でなければ登録できない' do
         @user.save
         another_user = FactoryBot.build(:user)
         another_user.email = @user.email
         another_user.valid?
-        expect(another_user.errors.full_messages).to include("Email has already been taken")
+        expect(another_user.errors.full_messages).to include('Email has already been taken')
       end
-      it 'emailに＠が含まれていない'do
-        @user.email = "testgmail.com"
+      it 'emailに＠が含まれていない' do
+        @user.email = 'testgmail.com'
         @user.valid?
-        expect(@user.errors.full_messages).to include ("Email is invalid")
+        expect(@user.errors.full_messages).to include('Email is invalid')
       end
       it 'passwordが空では登録できない' do
-        @user.password = ""
+        @user.password = ''
         @user.valid?
         expect(@user.errors.full_messages).to include("Password can't be blank")
       end
-      it 'passwordが5文字以下では登録できない'do
-        @user.password = "aa000"
+      it 'passwordが5文字以下では登録できない' do
+        @user.password = 'aa000'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password is too short (minimum is 6 characters)")
+        expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
       end
-      it 'passwordが数字のみでは登録できない'do
-        @user.password = "000000"
+      it 'passwordが数字のみでは登録できない' do
+        @user.password = '000000'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password Include both letters and numbers")
+        expect(@user.errors.full_messages).to include('Password Include both letters and numbers')
       end
-      it 'passwordが英字のみでは登録できない'do
-        @user.password = "aaaaaa"
+      it 'passwordが英字のみでは登録できない' do
+        @user.password = 'aaaaaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password Include both letters and numbers")
+        expect(@user.errors.full_messages).to include('Password Include both letters and numbers')
       end
       it 'passwordが全角では登録できない' do
-        @user.password = "ａａａ０００"
+        @user.password = 'ａａａ０００'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password Include both letters and numbers")
+        expect(@user.errors.full_messages).to include('Password Include both letters and numbers')
       end
       it 'passwordが存在してもpassword_confirmationが空では登録できない' do
-        @user.password_confirmation = ""
+        @user.password_confirmation = ''
         @user.valid?
         expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
       end
-       it 'passwordとpassword_confirmationが一致しない' do
-        @user.password = "aaa000"
-        @user.password_confirmation = "bbb111"
+      it 'passwordとpassword_confirmationが一致しない' do
+        @user.password = 'aaa000'
+        @user.password_confirmation = 'bbb111'
         @user.valid?
         expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
       end
       it '苗字が空だと登録できない' do
-        @user.last_name = ""
+        @user.last_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include ("Last name can't be blank")
+        expect(@user.errors.full_messages).to include("Last name can't be blank")
       end
       it '名前が空だと登録できない' do
-        @user.first_name = ""
+        @user.first_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include ("First name can't be blank")
+        expect(@user.errors.full_messages).to include("First name can't be blank")
       end
       it '苗字が英数字だと登録できない' do
-        @user.last_name = "aaaaa"
+        @user.last_name = 'aaaaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include ("Last name is invalid. Input full-width characters.")
+        expect(@user.errors.full_messages).to include('Last name is invalid. Input full-width characters.')
       end
       it '名前が英数字だと登録できない' do
-        @user.first_name = "aaaaa"
+        @user.first_name = 'aaaaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include ("First name is invalid. Input full-width characters.")
+        expect(@user.errors.full_messages).to include('First name is invalid. Input full-width characters.')
       end
       it 'カナ苗字が空だと登録できない' do
-        @user.last_name_kana = ""
+        @user.last_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include ("Last name kana can't be blank")
+        expect(@user.errors.full_messages).to include("Last name kana can't be blank")
       end
       it 'カナ名前が空だと登録できない' do
-        @user.first_name_kana = ""
+        @user.first_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include ("First name kana can't be blank")
+        expect(@user.errors.full_messages).to include("First name kana can't be blank")
       end
       it 'カナ苗字が漢字だと登録できない' do
-        @user.last_name_kana = "漢字"
+        @user.last_name_kana = '漢字'
         @user.valid?
-        expect(@user.errors.full_messages).to include ("Last name kana is invalid. Input full-width katakana characters.")
+        expect(@user.errors.full_messages).to include('Last name kana is invalid. Input full-width katakana characters.')
       end
       it 'カナ苗字が英数字だと登録できない' do
-        @user.last_name_kana = "kana"
+        @user.last_name_kana = 'kana'
         @user.valid?
-        expect(@user.errors.full_messages).to include ("Last name kana is invalid. Input full-width katakana characters.")
+        expect(@user.errors.full_messages).to include('Last name kana is invalid. Input full-width katakana characters.')
       end
       it 'カナ名前が漢字だと登録できない' do
-        @user.first_name_kana = "漢字"
+        @user.first_name_kana = '漢字'
         @user.valid?
-        expect(@user.errors.full_messages).to include ("First name kana is invalid. Input full-width katakana characters.")
+        expect(@user.errors.full_messages).to include('First name kana is invalid. Input full-width katakana characters.')
       end
       it 'カナ苗字が英数字だと登録できない' do
-        @user.first_name_kana = "kana"
+        @user.first_name_kana = 'kana'
         @user.valid?
-        expect(@user.errors.full_messages).to include ("First name kana is invalid. Input full-width katakana characters.")
+        expect(@user.errors.full_messages).to include('First name kana is invalid. Input full-width katakana characters.')
       end
       it '生年月日が空だと登録できない' do
-        @user.birthday = ""
+        @user.birthday = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include ("Birthday can't be blank")
+        expect(@user.errors.full_messages).to include("Birthday can't be blank")
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -30,7 +30,7 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
-I18n.locale = "en"
+I18n.locale = 'en'
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,53 +44,51 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end


### PR DESCRIPTION
#What
商品詳細表示機能を実装した
#Why
商品詳細の表示と編集、削除、購入画面への遷移ボタンを表示する為

商品出品時に登録した情報が見られるようになっていること
ログアウト状態のユーザーでも商品詳細表示ページを閲覧できる
ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されない
https://gyazo.com/b5d4231ec0518ccf061fff917d808211

ログイン状態の出品者のみ、「編集・削除ボタン」が表示されるhttps://gyazo.com/53498a002e4bf892ab9c3877e493630c

ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示される
https://gyazo.com/d13898229a37c1b164c3b541467a15fc